### PR TITLE
Serial port error info in UI

### DIFF
--- a/src/browser-common/replicants.ts
+++ b/src/browser-common/replicants.ts
@@ -10,10 +10,12 @@ export async function loadReplicants() {
 			}),
 			selectedPort: await replicant<string | null>("selectedPort", "glimpse-graphics.sync-settings", {defaultValue: null}),
 			selectedSport: await replicant<string>("selectedSport", "glimpse-graphics.sync-settings", {defaultValue: 'Hockey/Lacrosse'}),
-			status: await replicant<{ connected: boolean, bitrate: number }>("status", "glimpse-graphics.sync-settings", {
+			status: await replicant<{ connected: boolean, bitrate: number, error: boolean, errorMsg: string }>("status", "glimpse-graphics.sync-settings", {
 				defaultValue: {
 					connected: false,
-					bitrate: 0
+					bitrate: 0,
+					error: false,
+					errorMsg: "Error"
 				}, persistent: false
 			}),
 			values: {

--- a/src/dashboard/sync-settings/SyncSettings.vue
+++ b/src/dashboard/sync-settings/SyncSettings.vue
@@ -203,7 +203,9 @@ const availableSportsOptions = computed<{label: string, value: string}[]>(() => 
 
 // The color of the "light" on the serial port connection status indicator.
 const connLightColor = computed<string>(() => {
-	if (replicants.sync.status.value.connected) {
+	if (replicants.sync.status.value.error) {
+		return "#db9a4f";
+	} else if (replicants.sync.status.value.connected) {
 		return "#93db4f";
 	} else {
 		return "#eb7434";
@@ -212,7 +214,9 @@ const connLightColor = computed<string>(() => {
 
 // The text to display on the serial port connection status indicator.
 const connectedText = computed<string>(() => {
-	if(replicants.sync.status.value.connected) {
+	if (replicants.sync.status.value.error) {
+		return replicants.sync.status.value.errorMsg;
+	} else if(replicants.sync.status.value.connected) {
 		return 'Connected';
 	} else if(replicants.sync.selectedPort.value) {
 		return 'Connecting...';

--- a/src/extension/daktronics-rtd/protocol.ts
+++ b/src/extension/daktronics-rtd/protocol.ts
@@ -53,6 +53,8 @@ function bufferToHexString(data: Buffer) {
  *   {@link handlePacket}.
  */
 export function daktronicsRtdListener(data: Buffer) {
+	replicants.sync.status.value.error = false;
+
 	if(logger.isLevelEnabled("trace")) {
 		logger.trace({rawBytes: bufferToHexString(data)},'Received data from serial port');
 	}

--- a/src/extension/util/replicants.ts
+++ b/src/extension/util/replicants.ts
@@ -6,7 +6,14 @@ export const replicants = {
 		availablePorts: nodecg().Replicant<string[]>("availablePorts", "glimpse-graphics.sync-settings", {defaultValue: [], persistent: false}),
 		selectedPort: nodecg().Replicant<string|null>("selectedPort", "glimpse-graphics.sync-settings", {defaultValue: null}),
 		selectedSport: nodecg().Replicant<string>("selectedSport", "glimpse-graphics.sync-settings", {defaultValue: 'Hockey/Lacrosse'}),
-		status: nodecg().Replicant<{connected: boolean, bitrate: number}>("status", "glimpse-graphics.sync-settings", {defaultValue: {connected: false, bitrate: 0}, persistent: false}),
+		status: nodecg().Replicant<{ connected: boolean, bitrate: number, error: boolean, errorMsg: string }>("status", "glimpse-graphics.sync-settings", {
+			defaultValue: {
+				connected: false,
+				bitrate: 0,
+				error: false,
+				errorMsg: "Error"
+			}, persistent: false
+		}),
 		values: {
 			clock: nodecg().Replicant<boolean>("clock", "glimpse-graphics.sync-settings.values", {defaultValue: false}),
 			period: nodecg().Replicant<boolean>("period", "glimpse-graphics.sync-settings.values", {defaultValue: false}),


### PR DESCRIPTION
Should there be an error event from the SerialPort, the error message will be sent to the UI panel so the operator can see there is an error.

This came to my attention when `ERROR (22148): Opening COM1: Access denied` was sent into the console in a dev environment with no Daktronics connected to COM1.

It looked like the simple solution was to amend [Line 57 of protocol.ts](https://github.com/rpitv/glimpse-graphics/commit/6c9232f3ca9cedab71cc37ac471db50dffc9b1dc#diff-647b1056e9310a0379ac5e1471c29d155eda6720345197cd5cdf3f4e01890985L57) for the emmit event to be sent whenever the dev environment was hot reloading.

Having this info presented in the UI would allow for quick diagnosis should something be wrong before having to look at the actual server console.