### PR TITLE
Daktronics RTD data dumping improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ extension
 graphics
 node_modules
 shared
+dumps
 .gitattributes
 .gitignore
 docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
+dumps
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
@@ -102,7 +103,6 @@ dist
 
 # vuepress v2.x temp and cache directory
 .temp
-.cache
 
 # Docusaurus cache and generated files
 .docusaurus

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,6 +12,7 @@ services:
       - ./.nodecg/cfg:/usr/src/app/cfg
       - ./.nodecg/db:/usr/src/app/db
       - ./.nodecg/assets:/usr/src/app/assets
+      - ./dumps:/usr/src/app/dumps
       - .:/usr/src/app/bundles/glimpse-graphics
       - /usr/src/app/bundles/glimpse-graphics/node_modules
     command: npm --prefix "./bundles/glimpse-graphics" run dev

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - NODE_ENV=development
       - LOG_LEVEL=trace
+      - DUMP_RTD=false
     volumes:
       - ./.nodecg/cfg:/usr/src/app/cfg
       - ./.nodecg/db:/usr/src/app/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - ./.nodecg/cfg:/usr/src/app/cfg
       - ./.nodecg/db:/usr/src/app/db
       - ./.nodecg/assets:/usr/src/app/assets
+      - ./dumps:/usr/src/app/dumps
     networks:
       - glimpse_network
 networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@vueuse/core": "^9.5.0",
         "animejs": "^3.2.1",
+        "fs-extra": "^11.1.0",
         "module-alias": "^2.2.2",
         "pinia": "^2.0.23",
         "pino": "^8.7.0",
@@ -18,6 +19,7 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
+        "@types/fs-extra": "^11.0.1",
         "@types/node": "^16.11.47",
         "@types/uuid": "^8.3.4",
         "@vitejs/plugin-vue": "^2.3.3",
@@ -496,6 +498,16 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.1.tgz",
+      "integrity": "sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -511,6 +523,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.1.tgz",
+      "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/lodash": {
       "version": "4.14.182",
@@ -2310,17 +2331,16 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs.realpath": {
@@ -2472,8 +2492,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
@@ -3136,10 +3155,12 @@
       "dev": true
     },
     "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3465,6 +3486,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/nodecg-cli/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/nodecg-cli/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/nodecg-cli/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -3484,6 +3528,15 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/nodecg-cli/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/nodecg-types": {
@@ -5059,12 +5112,11 @@
       "dev": true
     },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/uri-js": {
@@ -5716,6 +5768,16 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.1.tgz",
+      "integrity": "sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==",
+      "dev": true,
+      "requires": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -5731,6 +5793,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "@types/jsonfile": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.1.tgz",
+      "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/lodash": {
       "version": "4.14.182",
@@ -7055,14 +7126,13 @@
       }
     },
     "fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       }
     },
     "fs.realpath": {
@@ -7171,8 +7241,7 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -7664,12 +7733,12 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
       }
     },
     "jsprim": {
@@ -7934,6 +8003,26 @@
             "supports-color": "^7.1.0"
           }
         },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
         "rimraf": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -7947,6 +8036,12 @@
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
           "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
         }
       }
@@ -9111,10 +9206,9 @@
       "dev": true
     },
     "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@vueuse/core": "^9.5.0",
     "animejs": "^3.2.1",
+    "fs-extra": "^11.1.0",
     "module-alias": "^2.2.2",
     "pinia": "^2.0.23",
     "pino": "^8.7.0",
@@ -32,6 +33,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/fs-extra": "^11.0.1",
     "@types/node": "^16.11.47",
     "@types/uuid": "^8.3.4",
     "@vitejs/plugin-vue": "^2.3.3",

--- a/src/extension/daktronics-rtd/protocol.ts
+++ b/src/extension/daktronics-rtd/protocol.ts
@@ -45,7 +45,6 @@ function bufferToHexString(data: Buffer) {
 	return hexDataStr.match(/.{1,2}/g)?.join(' ') ?? '';
 }
 
-
 const dumpQueue: (() => Promise<void>)[] = [];
 /**
  * Write an incoming data buffer to the dump file. This is useful for debugging and is enabled by default,

--- a/src/extension/daktronics-rtd/protocol.ts
+++ b/src/extension/daktronics-rtd/protocol.ts
@@ -45,8 +45,8 @@ function bufferToHexString(data: Buffer) {
 	return hexDataStr.match(/.{1,2}/g)?.join(' ') ?? '';
 }
 
-let dumpQueue: (() => Promise<void>)[] = [];
 
+const dumpQueue: (() => Promise<void>)[] = [];
 /**
  * Write an incoming data buffer to the dump file. This is useful for debugging and is enabled by default,
  *  but can be disabled by setting the DUMP_RTD environment variable to "false". Data is written in

--- a/src/extension/daktronics-rtd/protocol.ts
+++ b/src/extension/daktronics-rtd/protocol.ts
@@ -62,7 +62,7 @@ export function daktronicsRtdListener(data: Buffer) {
 	const d = new Date();
 	appendFile(`${__dirname}/_Daktronics_${d.getFullYear()}-${d.getMonth()}-${d.getDay()}.log`,
 		bufferToHexString(data) + "\n", (err) => {
-			logger.trace(
+			logger.trace(err,
 				`failed to save buffer"
 			${bufferToHexString(data)}
 			"to file: ${__dirname}/_Daktronics_${d.getFullYear()}-${d.getMonth()}-${d.getDay()}.log`)
@@ -165,7 +165,11 @@ function handlePacket(packet: Buffer): void {
 	}
 
 	// Call the handler for the packet, if it is defined.
-	const handler = sports[replicants.sync.selectedSport.value][id].handler;
+	const packetDef = sports[replicants.sync.selectedSport.value][id];
+	if(!packetDef) {
+		logger.trace(data, 'No packet definition for packet ID %d. Ignoring packet.', id)
+	}
+	const handler = packetDef.handler;
 	if(!handler) {
 		logger.trace('No handler defined for packet ID %d. Ignoring packet.', id);
 		return;

--- a/src/extension/daktronics-rtd/protocol.ts
+++ b/src/extension/daktronics-rtd/protocol.ts
@@ -1,7 +1,8 @@
 import {sports} from "./sports-definitions";
 import {replicants} from "../util/replicants";
 import {logger} from "../util/logger";
-import {appendFile} from "fs";
+import * as fs from 'fs-extra';
+import * as path from "path";
 
 const packetBytes: number[] = [];
 let computedChecksum = 0;
@@ -44,6 +45,50 @@ function bufferToHexString(data: Buffer) {
 	return hexDataStr.match(/.{1,2}/g)?.join(' ') ?? '';
 }
 
+let dumpQueue: (() => Promise<void>)[] = [];
+
+/**
+ * Write an incoming data buffer to the dump file. This is useful for debugging and is enabled by default,
+ *  but can be disabled by setting the DUMP_RTD environment variable to "false". Data is written in
+ *  the order it is received. Note that it always writes data to a file corresponding to the current
+ *  date. If the program is running at midnight, a packet could be split across two files.
+ *
+ *  Data is written to the "dumps" directory, with the name "Daktronics_<year>_<month>_<day>.dump". The
+ *  file and directory are created if they don't exist. If the write/creation fails, a debug is logged,
+ *  and no errors are thrown.
+ * @param data Incoming data buffer.
+ */
+async function writeToDumpFile(data: Buffer): Promise<void> {
+	const date = new Date();
+	const fileName = `Daktronics_${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate() + 1}.dump`
+	const directory = path.join(__dirname, '..', '..', 'dumps');
+	const filePath = path.join(directory, fileName);
+
+	const dumpFn = async () => {
+		try {
+			await fs.ensureFile(filePath);
+			await fs.appendFile(filePath, data);
+		} catch(err) {
+			logger.debug({error: err, data: bufferToHexString(data)},
+				`failed to write buffer to dump file ${filePath}`);
+		}
+	}
+
+	// To ensure that data is written in the correct order, we need to wait for the previous write to finish before
+	//  writing the next one. This may not be necessary due to the way the event loop functions, but it's better to be
+	//  safe than sorry for now.
+	dumpQueue.push(dumpFn);
+
+	// If this is the only dump queued up, then we can start writing it. We will then handle any
+	//  additional dumps that have been queued up.
+	if(dumpQueue.length === 1) {
+		while(dumpQueue[0] !== undefined) {
+			await dumpQueue[0]();
+			dumpQueue.shift();
+		}
+	}
+}
+
 /**
  * Handler for incoming data on a Daktronics RTD serial port. This function handles the raw data coming in from
  *   the serial port and parses it into packets. It then verifies the packets' checksums and passes them to the
@@ -58,15 +103,10 @@ export function daktronicsRtdListener(data: Buffer) {
 		logger.trace({rawBytes: bufferToHexString(data)},'Received data from serial port');
 	}
 
-	// dumping the Daktronics serial connection to a log file
-	const d = new Date();
-	appendFile(`${__dirname}/_Daktronics_${d.getFullYear()}-${d.getMonth()}-${d.getDay()}.log`,
-		bufferToHexString(data) + "\n", (err) => {
-			logger.trace(err,
-				`failed to save buffer"
-			${bufferToHexString(data)}
-			"to file: ${__dirname}/_Daktronics_${d.getFullYear()}-${d.getMonth()}-${d.getDay()}.log`)
-		})
+	// dumping the Daktronics serial connection to a dump file
+	if(process.env.DUMP_RTD !== "false") {
+		writeToDumpFile(data);
+	}
 
 	for(const byte of data) {
 		if(byte === 0x16) {
@@ -125,6 +165,7 @@ export function daktronicsRtdListener(data: Buffer) {
 	}
 }
 
+const packetFrequencies: {[key: number]: number} = {};
 function handlePacket(packet: Buffer): void {
 	// If selected sport is undefined or isn't in the sports list, then we don't know how to parse the packet.
 	if(!replicants.sync.selectedSport.value || !sports[replicants.sync.selectedSport.value]) {
@@ -139,6 +180,8 @@ function handlePacket(packet: Buffer): void {
 	// Get the ID. IDs are in the form "00421xxxxx", where "xxxxx" is the ID, all in ASCII. Add one, since it's zero-indexed
 	logger.trace('Getting the ID of the packet');
 	const id = parseInt(paddingStrippedData.slice(5, 10).toString('ascii'), 10) + 1;
+
+	packetFrequencies[id] = (packetFrequencies[id] || 0) + 1;
 
 	// Make sure this is a valid packet for this sport.
 	if(!sports[replicants.sync.selectedSport.value][id]) {
@@ -165,14 +208,18 @@ function handlePacket(packet: Buffer): void {
 	}
 
 	// Call the handler for the packet, if it is defined.
-	const packetDef = sports[replicants.sync.selectedSport.value][id];
-	if(!packetDef) {
-		logger.trace(data, 'No packet definition for packet ID %d. Ignoring packet.', id)
-	}
-	const handler = packetDef.handler;
+	const handler = sports[replicants.sync.selectedSport.value][id].handler;
 	if(!handler) {
-		logger.trace('No handler defined for packet ID %d. Ignoring packet.', id);
+		logger.debug('No handler defined for packet ID %d. Ignoring packet.', id);
 		return;
 	}
 	handler(trimmedData);
+}
+
+if(logger.isLevelEnabled("debug")) {
+	setInterval(() => {
+		logger.debug({
+			packetFrequencies
+		}, 'Packet frequencies');
+	}, 10000);
 }


### PR DESCRIPTION
- Data is now dumped to the `/dumps` directory.
- The raw bytes are dumped, instead of hexadecimal encoded bytes.
  - This allows you to directly feed the dump files into the mock bulk upload.
  - View hexadecimal with a hexadecimal editor, e.g. HxD, or by looking at the more in-depth stdout logs with log level set to TRACE.
- Dumps can be disabled by setting the `DUMP_RTD` environment variable to "false".
  - Dumps are disabled by default in Docker development environments.
- Fixed a bug where the dumps wouldn't write if the file or parent directory didn't exist.
- Fixed a bug causing the data dump file names to be incorrect.
- Added "packetFrequencies" logging
  - Every time any given packet ID is received, it is counted.
  - Total counts for each packet ID are logged every 10 seconds when logger level is set to DEBUG or lower.